### PR TITLE
Add Maven as dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ recipe           "sonar::proxy_nginx", "Includes the recipe to install Nginx-Web
   supports os
 end
 
-%w{ java }.each do |cb|
+%w{ java maven }.each do |cb|
   depends cb
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "info@christian-trabold.de"
 license          "Apache 2.0"
 description      "Installs/Configures sonar"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.0.2"
+version          "0.0.3"
 recipe           "sonar", "Includes the recipe to download and configure a sonar server"
 recipe           "sonar::database_mysql", "Includes the recipe to install MySql-Server and create a database for sonar"
 recipe           "sonar::proxy_apache", "Includes the recipe to install Apache-Webserver and proxy modules to access sonar. Creates a host for sonar."


### PR DESCRIPTION
Chef (version 0.10) complains when using "include_recipe" without declaring it as dependency in the metadata. The maven dependency is mandatory as it is in the default recipe.
