### PR TITLE
Addding mirror support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ default['sonar']['dir']       = "/opt/sonar"
 default['sonar']['version']   = "2.11"
 default['sonar']['checksum']  = "9d05e25ca79c33d673004444d89c8770"
 default['sonar']['os_kernel'] = "linux-x86-32"
+default['sonar']['mirror']    = "http://dist.sonar.codehaus.org"
 
 # Web settings
 # The default listen port is 9000, the default context path is / and Sonar listens by default to all network interfaces : '0.0.0.0'.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ include_recipe "maven"
 package "unzip"
 
 remote_file "/opt/sonar-#{node['sonar']['version']}.zip" do
-  source "http://dist.sonar.codehaus.org/sonar-#{node['sonar']['version']}.zip"
+  source "#{node['sonar']['mirror']}/sonar-#{node['sonar']['version']}.zip"
   mode "0644"
   checksum "#{node['sonar']['checksum']}"
   not_if {File.exists?("/opt/sonar-#{node['sonar']['version']}.zip")}


### PR DESCRIPTION
As yesterday the http://dist.sonar.codehaus.org server was down (at least from here, in France), I've added the possibility to specify a mirror (which could be internal for quicker download).

Feel free to add it or not ;-)
