### PR TITLE
mysql and sonar-plugin support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,9 +1,11 @@
 # General settings
 default['sonar']['dir']       = "/opt/sonar"
-default['sonar']['version']   = "2.11"
+default['sonar']['version']   = "2.13.1"
 default['sonar']['checksum']  = "9d05e25ca79c33d673004444d89c8770"
 default['sonar']['os_kernel'] = "linux-x86-32"
 default['sonar']['mirror']    = "http://dist.sonar.codehaus.org"
+default['sonar']['plugins_repo']    = "http://repository.codehaus.org/org/codehaus/sonar-plugins"
+default['sonar']['plugins_dir']    = "extensions/plugins"
 
 # Web settings
 # The default listen port is 9000, the default context path is / and Sonar listens by default to all network interfaces : '0.0.0.0'.

--- a/definitions/default.rb
+++ b/definitions/default.rb
@@ -1,0 +1,10 @@
+define :sonar_plugin, :version => "1.0" do
+ remote_file "#{node[:sonar][:dir]}/#{node[:sonar][:plugins_dir]}/#{params[:name]}-#{params[:version]}.jar" do
+    source "#{node[:sonar][:plugins_repo]}/#{params[:name]}/#{params[:version]}/#{params[:name]}-#{params[:version]}.jar"
+    owner "root"
+    group "root"
+    mode 0755
+    notifies :restart, resources(:service => "sonar")
+    not_if "test -f #{node[:sonar][:dir]}/#{node[:sonar][:plugins_dir]}/#{params[:name]}-#{params[:version]}.jar"
+ end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,14 @@ link "/opt/sonar" do
   to "/opt/sonar-#{node['sonar']['version']}"
 end
 
+file "/etc/init.d/sonar" do
+    path "/opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh"
+    owner "root"
+    group "root"
+    mode "0755"
+    action :create
+end
+
 service "sonar" do
   stop_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh stop"
   start_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh start"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,20 +36,13 @@ link "/opt/sonar" do
   to "/opt/sonar-#{node['sonar']['version']}"
 end
 
-file "/etc/init.d/sonar" do
-    path "/opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh"
-    owner "root"
-    group "root"
-    mode "0755"
-    action :create
+link "/etc/init.d/sonar" do
+  to "/opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh"
 end
 
 service "sonar" do
-  stop_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh stop"
-  start_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh start"
-  status_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh status"
-  restart_command "sh /opt/sonar/bin/#{node['sonar']['os_kernel']}/sonar.sh restart"
-  action :start
+  supports :status => true, :restart => true
+  action :enable
 end
 
 template "sonar.properties" do

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -19,9 +19,9 @@
 
 # Database settings
 # @see conf/sonar.properties for examples for different databases
-override['sonar']['jdbc_url']             = "jdbc:mysql://localhost:3306/sonar?useUnicode=true&characterEncoding=utf8"
-override['sonar']['jdbc_driverClassName'] = "com.mysql.jdbc.Driver"
-override['sonar']['jdbc_validationQuery'] = "select 1"
+node.default['sonar']['jdbc_url']             = "jdbc:mysql://localhost:3306/sonar?useUnicode=true&characterEncoding=utf8"
+node.default['sonar']['jdbc_driverClassName'] = "com.mysql.jdbc.Driver"
+node.default['sonar']['jdbc_validationQuery'] = "select 1"
 
-include "default"
-include "database_mysql"
+include_recipe "sonar::default"
+include_recipe "sonar::database_mysql"

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: sonar
+# Recipe:: mysql
+#
+# Copyright 2011, Srinivasan Raguraman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Database settings
+# @see conf/sonar.properties for examples for different databases
+override['sonar']['jdbc_url']             = "jdbc:mysql://localhost:3306/sonar?useUnicode=true&characterEncoding=utf8"
+override['sonar']['jdbc_driverClassName'] = "com.mysql.jdbc.Driver"
+override['sonar']['jdbc_validationQuery'] = "select 1"
+
+include "default"
+include "database_mysql"

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -1,0 +1,5 @@
+# installs common sonar plugins used enterprise wide
+#
+
+sonar_plugin "sonar-build-breaker-plugin"
+sonar_plugin "sonar-taglist-plugin"


### PR DESCRIPTION
supports installation through mysql.

supports installation of sonar plugins from codehaus repo. Also exposed as definition so could be used in other recipes.
